### PR TITLE
Initialize automatic build with GitHub actions

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -1,0 +1,21 @@
+---
+name: build
+
+on:
+  push:
+    branches:
+      - main
+    tags-ignore:
+      - "*"
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch: {}
+
+concurrency:
+  group: build-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    uses: jqassistant-tooling/jqassistant-github-actions/.github/workflows/ci-build.yml@main


### PR DESCRIPTION
FYI, it worked as expected on my fork: https://github.com/murdos/jqassistant-jmolecules-plugin/actions/runs/6177243200